### PR TITLE
Fix double degree-to-radian conversion in complex magnitude/phase inputs

### DIFF
--- a/suncal/uncertainty/model_cplx.py
+++ b/suncal/uncertainty/model_cplx.py
@@ -176,8 +176,12 @@ class RandomVariableCplx:
             mag.measure(np.real(self.value[0]))
             mag.typeb(std=np.real(self.uncertainty[0]))
             deg = RandomVariable()
-            deg.measure(np.deg2rad(np.real(self.value[1])))
-            deg.typeb(std=np.deg2rad(np.real(self.uncertainty[1])))
+            # Keep degree values as degrees. The degree-to-radian conversion is
+            # applied by the consuming model (the sympy pi/180*deg substitution in
+            # ModelComplex, and the pi/180 factor in _wrap_callable). Converting
+            # here as well double-counts it and corrupts the propagated uncertainty.
+            deg.measure(np.real(self.value[1]))
+            deg.typeb(std=np.real(self.uncertainty[1]))
             randvars = {f'{self.name}_mag': mag, f'{self.name}_deg': deg}
 
         return randvars

--- a/test/test_cplx.py
+++ b/test/test_cplx.py
@@ -34,6 +34,60 @@ def test_E15():
     assert np.isclose(mc.correlation()['Gamma_real']['Gamma_imag'], 0.0323, atol=.005)
 
 
+def test_magphase_degrees():
+    ''' Phase entered in degrees must give the same result as the equivalent
+        phase entered in radians (regression for double degree->radian conversion). '''
+    # Passthrough model: output uncertainty should equal the input uncertainty
+    deg = ModelComplex('Z11=S11', magphase=True)
+    deg.var('S11').measure_magphase(magnitude=50, phase=10, umagnitude=0.5, uphase=1,
+                                    degrees=True, k=1)
+    gdeg = deg.calculate_gum()
+    assert np.isclose(gdeg.expected['Z11_mag'], 50)
+    assert np.isclose(gdeg.uncertainty['Z11_mag'], 0.5)
+    assert np.isclose(gdeg.expected['Z11_rad'], np.deg2rad(10))
+    assert np.isclose(gdeg.uncertainty['Z11_rad'], np.deg2rad(1))
+
+    # degrees=True must match the same measurement pre-converted to radians
+    rad = ModelComplex('Z11=S11', magphase=True)
+    rad.var('S11').measure_magphase(magnitude=50, phase=np.deg2rad(10),
+                                    umagnitude=0.5, uphase=np.deg2rad(1),
+                                    degrees=False, k=1)
+    grad = rad.calculate_gum()
+    for key in gdeg.expected:
+        assert np.isclose(gdeg.expected[key], grad.expected[key])
+        assert np.isclose(gdeg.uncertainty[key], grad.uncertainty[key])
+
+
+def test_magphase_degrees_callable():
+    ''' Same degree/radian check through the callable path (_wrap_callable),
+        the other consumer of the doubly-converted phase variable. '''
+    from suncal.uncertainty import ModelComplexCallable
+
+    def passthrough(S11):
+        return S11
+
+    m = ModelComplexCallable(passthrough, magphase=True)
+    m.var('S11').measure_magphase(magnitude=50, phase=10, umagnitude=0.5,
+                                  uphase=1, degrees=True, k=1)
+    g = m.calculate_gum()
+    assert np.isclose(g.expected['passthrough_mag'], 50)
+    assert np.isclose(g.uncertainty['passthrough_mag'], 0.5)
+    assert np.isclose(g.expected['passthrough_rad'], np.deg2rad(10))
+    assert np.isclose(g.uncertainty['passthrough_rad'], np.deg2rad(1))
+
+
+def test_magphase_degrees_montecarlo():
+    ''' Monte Carlo shares _build_model_sympy, so degree input must also match
+        the equivalent radian input there. '''
+    np.random.seed(2038942)
+    deg = ModelComplex('Z11=S11', magphase=True)
+    deg.var('S11').measure_magphase(magnitude=50, phase=10, umagnitude=0.5,
+                                    uphase=1, degrees=True, k=1)
+    mc = deg.monte_carlo(samples=100000)
+    assert np.isclose(mc.expected['Z11_rad'], np.deg2rad(10), atol=1e-4)
+    assert np.isclose(mc.uncertainty['Z11_rad'], np.deg2rad(1), atol=1e-4)
+
+
 def test_parse():
     ''' Test parsing expression with cplx '''
     expr = 'I * omega * C'


### PR DESCRIPTION
Fixes #25.

## Problem

`measure_magphase(..., degrees=True)` applied the degree-to-radian conversion twice.

`RandomVariableCplx.get_randvars()` converts the phase value and uncertainty to radians for the `madegrees` type, but stores them under the `_deg` name. Both downstream consumers then convert again:

- `ModelComplex._build_model_sympy()` substitutes the phase symbol as `mag*cos(pi/180*deg) + i*mag*sin(pi/180*deg)`.
- `_wrap_callable()` computes `rad = pi/180 * kwargs['{name}_deg']`.

So the phase (and its uncertainty) were scaled by an extra factor of `pi/180`, giving incorrect expected values and uncertainties whenever `degrees=True` was used.

## Fix

Keep the phase in degrees inside `get_randvars()` so the single conversion performed by the model is correct, matching the existing radian (`ma`) code path.

## Verification

Using the reproducer from the issue (`Z11 = S11` pass-through, `magnitude=50, phase=10, umagnitude=0.5, uphase=1, degrees=True, k=1`):

| quantity | before | after | expected |
|---|---|---|---|
| `Z11_rad` value | 0.003046 | 0.174533 | 0.174533 (= 10°) |
| `Z11_rad` uncertainty | 0.000305 | 0.017453 | 0.017453 (= 1°) |

The pass-through model now returns the input uncertainty unchanged, and degree input yields the same result as the equivalent radian input. A regression test (`test_magphase_degrees`) is added covering both the pass-through expectation and degree/radian equivalence. The full existing test suite passes.